### PR TITLE
Enable working with private repositories

### DIFF
--- a/org.eclipse.mylyn.github.core/src/org/eclipse/mylyn/github/internal/GitHubRepositoryConnector.java
+++ b/org.eclipse.mylyn.github.core/src/org/eclipse/mylyn/github/internal/GitHubRepositoryConnector.java
@@ -24,6 +24,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.mylyn.commons.net.AuthenticationCredentials;
+import org.eclipse.mylyn.commons.net.AuthenticationType;
 import org.eclipse.mylyn.tasks.core.AbstractRepositoryConnector;
 import org.eclipse.mylyn.tasks.core.IRepositoryQuery;
 import org.eclipse.mylyn.tasks.core.ITask;
@@ -126,10 +128,13 @@ public class GitHubRepositoryConnector extends AbstractRepositoryConnector {
 		try {
 			String user = buildTaskRepositoryUser(repository.getUrl());
 			String project = buildTaskRepositoryProject(repository.getUrl());
+			AuthenticationCredentials auth = repository.getCredentials(AuthenticationType.REPOSITORY);
+			GitHubCredentials credentials = new GitHubCredentials(auth.getUserName(), auth.getPassword());
+			
 			for (String status : statuses) {
 				GitHubIssues issues = service
 						.searchIssues(user, project, status,
-								query.getAttribute(GitHub.QUERY_TEXT_ATTRIBUTE));
+								query.getAttribute(GitHub.QUERY_TEXT_ATTRIBUTE), credentials);
 				for (GitHubIssue issue : issues.getIssues()) {
 					TaskData taskData = taskDataHandler.createTaskData(
 							repository, monitor, user, project, issue, true);

--- a/org.eclipse.mylyn.github.core/src/org/eclipse/mylyn/github/internal/GitHubService.java
+++ b/org.eclipse.mylyn.github.core/src/org/eclipse/mylyn/github/internal/GitHubService.java
@@ -68,34 +68,6 @@ public class GitHubService {
 	}
 
 	/**
-	 * Verify that the provided credentials are correct
-	 * 
-	 * @param credentials
-	 *            - user credentials
-	 * 
-	 * @return true if and only if the credentials are correct
-	 */
-	public final boolean verifyCredentials(GitHubCredentials credentials)
-			throws GitHubServiceException {
-		PostMethod method = null;
-		boolean success = false;
-		try {
-			method = new PostMethod(API_URL_BASE + API_ISSUES_ROOT + EMAILS);
-			method.setRequestBody(getCredentials(credentials));
-			executeMethod(method);
-			success = true;
-		} catch (PermissionDeniedException e) {
-			LOG.error("Invalid credentials.", e);
-			return false;
-		} finally {
-			if (method != null) {
-				method.releaseConnection();
-			}
-		}
-		return success;
-	}
-
-	/**
 	 * Search the GitHub Issues API for a given search term
 	 * 
 	 * @param user

--- a/org.eclipse.mylyn.github.core/src/org/eclipse/mylyn/github/internal/GitHubService.java
+++ b/org.eclipse.mylyn.github.core/src/org/eclipse/mylyn/github/internal/GitHubService.java
@@ -115,18 +115,19 @@ public class GitHubService {
 	 * @note API Doc: /issues/search/:user/:repo/:state/:search_term
 	 */
 	public final GitHubIssues searchIssues(final String user,
-			final String repo, final String state, final String searchTerm)
+			final String repo, final String state, final String searchTerm, final GitHubCredentials credentials)
 			throws GitHubServiceException {
 		GitHubIssues issues = null;
-		GetMethod method = null;
+		PostMethod method = null;
 		try {
 			if (searchTerm.trim().length() == 0) {
-				method = new GetMethod(API_URL_BASE + API_ISSUES_ROOT + LIST
+				method = new PostMethod(API_URL_BASE + API_ISSUES_ROOT + LIST
 						+ user + "/" + repo + "/" + state);
 			} else {
-				method = new GetMethod(API_URL_BASE + API_ISSUES_ROOT + SEARCH
+				method = new PostMethod(API_URL_BASE + API_ISSUES_ROOT + SEARCH
 						+ user + "/" + repo + "/" + state + "/" + searchTerm);
 			}
+			method.setRequestBody(getCredentials(credentials));
 			executeMethod(method);
 			issues = gson.fromJson(new String(method.getResponseBody()),
 					GitHubIssues.class);

--- a/org.eclipse.mylyn.github.ui/src/org/eclipse/mylyn/github/ui/internal/GitHubRepositorySettingsPage.java
+++ b/org.eclipse.mylyn.github.ui/src/org/eclipse/mylyn/github/ui/internal/GitHubRepositorySettingsPage.java
@@ -124,16 +124,13 @@ public class GitHubRepositorySettingsPage extends
 							return;
 						}
 
-						// verify if the credentials supplied are correct
+						
+						monitor.worked(200);
+						
+						// verify if the credentials supplied are correct and if the task repository can be found
+						// note: github will allow you to view public issues, without a token with write-access for that repo.
+						// it will however return a 401 if you try to connect with an incorrect token included.
 						GitHubCredentials credentials = new GitHubCredentials(auth.getUserName(), auth.getPassword());
-						
-						if (!service.verifyCredentials(credentials)) {
-							setStatus(GitHubUi.createErrorStatus("Invalid credentials.  Please check your GitHub User ID and API Token.\nYou can find your API Token on your GitHub account settings page."));
-							return;	
-						}
-						monitor.worked(400);
-						
-						// verify the repo (by using credentials to request issue list)
 						service.searchIssues(user, repo, "open","", credentials);
 
 					} catch (GitHubServiceException e) {

--- a/org.eclipse.mylyn.github.ui/src/org/eclipse/mylyn/github/ui/internal/GitHubRepositorySettingsPage.java
+++ b/org.eclipse.mylyn.github.ui/src/org/eclipse/mylyn/github/ui/internal/GitHubRepositorySettingsPage.java
@@ -117,20 +117,25 @@ public class GitHubRepositorySettingsPage extends
 	
 					monitor.subTask("Contacting server...");
 					try {
-						// verify the repo
-						service.searchIssues(user, repo, "open","");
-						monitor.worked(400);
 						
-						// verify the credentials
+						// verify if the credentials were filled in by the user
 						if (auth == null) {
 							setStatus(GitHubUi.createErrorStatus("Credentials are required.  Please specify username and API Token."));
 							return;
 						}
+
+						// verify if the credentials supplied are correct
 						GitHubCredentials credentials = new GitHubCredentials(auth.getUserName(), auth.getPassword());
+						
 						if (!service.verifyCredentials(credentials)) {
 							setStatus(GitHubUi.createErrorStatus("Invalid credentials.  Please check your GitHub User ID and API Token.\nYou can find your API Token on your GitHub account settings page."));
 							return;	
 						}
+						monitor.worked(400);
+						
+						// verify the repo (by using credentials to request issue list)
+						service.searchIssues(user, repo, "open","", credentials);
+
 					} catch (GitHubServiceException e) {
 						setStatus(GitHubUi.createErrorStatus("Repository Test failed:"+ e.getMessage()));
 						return;


### PR DESCRIPTION
I was prevented from adding my private repos because the token was not used for fetching the issue list. 

Also GitHub was giving errors when verifying my credentials using the seperate method for this, but since this action was now obsolete I removed the whole method. 

It bothered me enough though to now have found what it was, during your refactor you changed the /user/ path to /issue/ in the API call. You can reject my second commit in this pull request and fix it in your code if you prefer to keep a seperate request for verifying the token.

I added a comment to the check in as well.
