### PR TITLE
Suggested fix for #10, and ensure ui/core use the same mylyn version

### DIFF
--- a/org.eclipse.mylyn.github.feature/feature.xml
+++ b/org.eclipse.mylyn.github.feature/feature.xml
@@ -23,10 +23,14 @@ Version 2.0, January 2004
 
    <requires>
       <import plugin="org.eclipse.core.runtime" version="3.5.0" match="greaterOrEqual"/>
+      <import plugin="com.google.gson" version="1.6.0" match="greaterOrEqual"/>
+      <import plugin="org.apache.commons.logging" version="1.1.1" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.mylyn.tasks.core" version="3.4.2" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.mylyn.commons.net" version="3.4.1" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui" version="3.5.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui.forms" version="3.4.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.mylyn.tasks.core" version="3.2.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.mylyn.tasks.ui" version="3.2.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.jface.text" version="3.5.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.mylyn.tasks.ui" version="3.4.3" match="greaterOrEqual"/>
    </requires>
 
    <plugin
@@ -38,6 +42,20 @@ Version 2.0, January 2004
 
    <plugin
          id="org.eclipse.mylyn.github.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.commons.logging"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.google.gson"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/org.eclipse.mylyn.github.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.mylyn.github.ui/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.5.0",
  org.eclipse.ui;bundle-version="3.5.0",
  org.eclipse.ui.forms;bundle-version="3.4.0",
  org.eclipse.jface.text;bundle-version="3.5.0",
- org.eclipse.mylyn.commons.net;bundle-version="3.2.0",
+ org.eclipse.mylyn.commons.net;bundle-version="3.4.1",
  org.eclipse.mylyn.github.core;bundle-version="0.2.2",
  org.eclipse.mylyn.tasks.ui;bundle-version="3.4.3"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6


### PR DESCRIPTION
This fixes installation for me, building/packaging with maven, though for Eclipse to install the dependencies gson/commons I first completely had to uninstall the connector (upgrading an already installed connector will not add the missing dependencies).

P2 pretty much does all the work for the dependencies (the requires section is probably not needed), but the inclusion in features ensures the plugins get copied to the update site.
