### PR TITLE
Fix the issues URI

### DIFF
--- a/org.eclipse.mylyn.github.core/src/org/eclipse/mylyn/github/internal/AbstractGitHubService.java
+++ b/org.eclipse.mylyn.github.core/src/org/eclipse/mylyn/github/internal/AbstractGitHubService.java
@@ -4,6 +4,7 @@
 package org.eclipse.mylyn.github.internal;
 
 import static org.eclipse.mylyn.github.internal.GitHubRepositoryUrlBuilder.buildTaskRepositoryProject;
+import static org.eclipse.mylyn.github.internal.GitHubRepositoryUrlBuilder.buildTaskRepositoryUserName;
 
 import java.io.IOException;
 
@@ -96,7 +97,7 @@ public abstract class AbstractGitHubService {
 	}
 
 	protected final String getTaskRepositoryUserName() {
-		return getTaskRepository().getUserName();
+		return buildTaskRepositoryUserName(getTaskRepository().getUrl());
 	}
 
 	protected final String getTaskRepositoryProjectName() {

--- a/org.eclipse.mylyn.github.core/src/org/eclipse/mylyn/github/internal/GitHubRepositoryUrlBuilder.java
+++ b/org.eclipse.mylyn.github.core/src/org/eclipse/mylyn/github/internal/GitHubRepositoryUrlBuilder.java
@@ -31,6 +31,15 @@ public final class GitHubRepositoryUrlBuilder {
 		return null;
 	}
 
+	public static String buildTaskRepositoryUserName(String repositoryUrl) {
+		Matcher matcher = GitHub.URL_PATTERN.matcher(repositoryUrl);
+		if (matcher.matches()) {
+			return matcher.group(1);
+		}
+		return null;
+	}
+
+
 	/**
 	 * Uses github.com
 	 * 


### PR DESCRIPTION
Hi

The connector constructs the URI to the issues with the user's GitHub ID.
When you try to connect to the issues in a repo of another user (or an organization),
it fails with a _HTTP 404 error: Not Found_.

I mean, with:
- **URL:** `http://github.com/schacon/showoff`
- **USER:** smancill

the issues URI is:
- `https://github.com/api/v2/json/issues/list/smancill/showoff/open`

which is the wrong repository.

Now the URI is constructed with the user in the repo URL, and the connector can
retrieve issues from repositories of other users:
- `https://github.com/api/v2/json/issues/list/schacon/showoff/open`

I hope this patch be useful.

Best regards.
